### PR TITLE
Check whether term is powershell and escape in the same way as cmd

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ function applyConfig() {
 			}
 		}
 
-		let isWindowsCmd = term?.toLowerCase().endsWith("cmd.exe") ?? false;
+		let isWindowsCmd = (term?.toLowerCase().endsWith("cmd.exe") || term?.toLowerCase().endsWith("powershell.exe")) ?? false;
 		windowsNeedsEscape = !isWindowsCmd;
 		// CMD doesn't support single quote.
 		fzfQuote = isWindowsCmd ? '"' : "'";


### PR DESCRIPTION
I attempted to use this plugin on my windows machine but none of the commands worked as expected. My integrated terminal seems to use powershell instead of cmd. As an example, when using the command "fzf: Search using rg and fzf" I was presented with the fzf search, but upon pressing enter I received the error message "The specified path is invalid". By hard coding `windowsNeedsEscape` to `false` I was able to get the various search commands working. As such I included a check for powershell like so::

```js
let isWindowsCmd = (term?.toLowerCase().endsWith("cmd.exe") || term?.toLowerCase().endsWith("powershell.exe")) ?? false;
```

so that `windowsNeedsEscape` ends up being `false` which prevents the erroneous escaping being applied in powershell. 