### PR TITLE
Add: fzf-open-file-git-project-root command and fzf-search-git-project-root - #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ On terminal launch, the `pwd` is chosen based on the active editor file. Also ad
 
 which are the same as above but switches to parent directory of active file on every invocation.
 
+On terminal launch, the `Project Root (.git)` is opened based on the results of `git rev-parse --show-toplevel` on the active editor file. Also adds
+
+* `fzf: Search in Project Root (.git) using rg and fzf`
+* `fzf: Open file in Project Root (.git) using fzf`
+
+which are the same as the above but switches to project root directory of the active file on every invocation.
+
 Bind the commands to keyboard shortcuts to launch faster.
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "onCommand:fzf-quick-open.runFzfAddWorkspaceFolder",
     "onCommand:fzf-quick-open.runFzfAddWorkspaceFolderPwd",
     "onCommand:fzf-quick-open.runFzfSearch",
-    "onCommand:fzf-quick-open.runFzfSearchPwd"
+    "onCommand:fzf-quick-open.runFzfSearchPwd",
+    "onCommand:fzf-quick-open.runFzfSearchProjectRoot"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -56,6 +57,10 @@
       {
         "command": "fzf-quick-open.runFzfSearchPwd",
         "title": "fzf: Search in PWD using rg and fzf"
+      },
+      {
+        "command": "fzf-quick-open.runFzfSearchProjectRoot",
+        "title": "fzf: Search in Project Root (.git) using rg and fzf"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "activationEvents": [
     "onCommand:fzf-quick-open.runFzfFile",
     "onCommand:fzf-quick-open.runFzfFilePwd",
+    "onCommand:fzf-quick-open.runFzfFileProjectRoot",
     "onCommand:fzf-quick-open.runFzfAddWorkspaceFolder",
     "onCommand:fzf-quick-open.runFzfAddWorkspaceFolderPwd",
     "onCommand:fzf-quick-open.runFzfSearch",
@@ -35,6 +36,10 @@
       {
         "command": "fzf-quick-open.runFzfFilePwd",
         "title": "fzf: Open file in PWD using fzf"
+      },
+      {
+        "command": "fzf-quick-open.runFzfFileProjectRoot",
+        "title": "fzf: Open file in Project Root (.git) using fzf"
       },
       {
         "command": "fzf-quick-open.runFzfAddWorkspaceFolder",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,9 @@ let fzfPipeScript: string;
 let windowsNeedsEscape = false;
 let fzfQuote = "'";
 
+const gitTopLevelDirectoryCmd_Win32 = "for /f %a in ('git rev-parse --show-toplevel') do cd %a";
+const gitTopLevelDirectoryCmd_Unix = "cd $(git rev-parse --show-toplevel)";
+
 export const TERMINAL_NAME = "fzf terminal";
 export const TERMINAL_NAME_PWD = "fzf pwd terminal";
 
@@ -254,6 +257,16 @@ export function activate(context: vscode.ExtensionContext) {
 		let term = showFzfTerminal(TERMINAL_NAME_PWD, fzfTerminalPwd);
 		moveToPwd(term);
 		term.sendText(getCodeOpenFileCmd(), true);
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('fzf-quick-open.runFzfFileProjectRoot', () => {
+		let term = showFzfTerminal(TERMINAL_NAME, fzfTerminal);
+		moveToPwd(term);
+		if (isWindows()) {
+			term.sendText(`${gitTopLevelDirectoryCmd_Win32} && ${getCodeOpenFileCmd()}`, true);
+		} else {
+			term.sendText(`${gitTopLevelDirectoryCmd_Unix} && ${getCodeOpenFileCmd()}`, true);
+		}
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('fzf-quick-open.runFzfAddWorkspaceFolder', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -299,6 +299,20 @@ export function activate(context: vscode.ExtensionContext) {
 		term.sendText(makeSearchCmd(pattern), true);
 	}));
 
+	context.subscriptions.push(vscode.commands.registerCommand('fzf-quick-open.runFzfSearchProjectRoot', async () => {
+		let pattern = await getSearchText();
+		if (pattern === undefined) {
+			return;
+		}
+		let term = showFzfTerminal(TERMINAL_NAME_PWD, fzfTerminalPwd);
+		moveToPwd(term);
+		if (isWindows()) {
+			term.sendText(`${gitTopLevelDirectoryCmd_Win32} && ${makeSearchCmd(pattern)}`, true);
+		} else {
+			term.sendText(`${gitTopLevelDirectoryCmd_Unix} && ${makeSearchCmd(pattern)}`, true);
+		}
+	}));
+
 	vscode.window.onDidCloseTerminal((terminal) => {
 		switch (terminal.name) {
 			case TERMINAL_NAME:


### PR DESCRIPTION
This PR closes issue #32.

As per @bergmul request, I've added two new commands that will allow for open or search at the project root (assuming .git folder as project root).

> fzf: Open file in Project using fzf
```Json
{
    "command": "fzf-quick-open.runFzfFileProjectRoot",
    "title": "fzf: Open file in Project Root (.git) using fzf"
}
```

> fzf: Search in Project using rg and fzf
```Json
{
    "command": "fzf-quick-open.runFzfSearchProjectRoot",
    "title": "fzf: Search in Project Root (.git) using rg and fzf"
}
```
